### PR TITLE
add bosh manifest v2 for openstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ VMs.
 Additionally, it serves as a good starting point, should you want to `bosh-gen extract-job`
 into your own BOSH release, to make it easier to tie a cronjob to your specific release.
 
+### Deploying
+Modify the sample stubs to suit your deployment environment in `templates`.
+
+The next step is to to generate the manifest file that will be used for deployment. Run the `make_manifest` script  `./templates/make_manifest <openstack|warden|aws>`. 
+
+If are using an Openstack environment, the cron release can be deployed using the bosh v2 manifest (must have a cloud-config in your current bosh).
+You have to modify the manifest-openstack.yml file to suit your deployment environment.
+
+ 
+
 
 ### Colocation Instructions
 

--- a/templates/deployment-openstack.yml
+++ b/templates/deployment-openstack.yml
@@ -1,0 +1,30 @@
+name: (( grab meta.environment ))
+
+director_uuid: de55efe0-b372-4840-90a4-888b28789fdf
+
+releases: ~ # merged from stub-openstack
+
+jobs: ~ # merged from jobs-openstack
+
+compilation:
+  workers: 2
+  network: my_network
+  reuse_compilation_vms: true
+  cloud_properties:
+    instance_type: n1.cw.highcpu-2
+    disk: 20000
+
+update:
+  canaries: 1
+  max_in_flight: 1
+  canary_watch_time: 30000-60000
+  update_watch_time: 5000-60000
+  serial: false
+
+resource_pools:
+  - name: small_z1
+    network: my_network
+    stemcell: (( grab meta.stemcell ))
+    cloud_properties:
+      instance_type: n2.cw.standard-1
+      disk: 10000

--- a/templates/infrastructure-openstack.yml
+++ b/templates/infrastructure-openstack.yml
@@ -1,0 +1,39 @@
+meta:
+  environment: cron-openstack
+
+  stemcell:
+    name: bosh-openstack-kvm-ubuntu-trusty-go_agent
+    version: latest
+
+update:
+  canaries: 1
+  max_in_flight: 50
+  canary_watch_time: 1000-30000
+  update_watch_time: 1000-30000
+
+jobs:
+  - name: cron
+    networks:
+      - name: my_network
+
+compilation:
+  cloud_properties:
+    name: random
+
+resource_pools:
+  - name: small_z1
+    cloud_properties:
+      name: random
+
+networks:
+- name: cron1
+  type: manual
+  subnets:
+  - range: 10.250.2.0/24
+    name: cron1
+    gateway: 10.250.2.1
+    static:
+      - 10.250.2.2 - 10.250.2.60
+    cloud_properties:
+      net_id: d3b8b007-0b17-42f4-9908-6274ea7b22d3
+      security_groups: [tf-bosh,default]

--- a/templates/jobs-openstack.yml
+++ b/templates/jobs-openstack.yml
@@ -1,0 +1,45 @@
+meta:
+  environment: ~
+
+update:
+  canaries: 1
+  max_in_flight: 50
+  canary_watch_time: 1000-30000
+  update_watch_time: 1000-30000
+  serial: false
+
+jobs:
+  - name: cron
+    templates:
+    - name: cron
+      release: cron
+    instances: 1
+    persistent_disk: 0
+    resource_pool: small_z1
+    networks:
+      - name: my_network
+        default: [dns,gateway]
+        static_ips:
+        - 10.250.2.55
+
+networks:
+properties:
+  cron:
+    #uncomment if you want to use arguments
+    #variables: # a key-value map of any environment variables you want set in the crontab
+     # VAR1: val1
+     # VAR2: val2
+    entries: # a list of key-value objects representing cron entries
+    - command: sudo echo "hello" > /tmp/test_file
+      minute: '*'
+      hour: '*'
+      day: '*'
+      month: '*'
+      user: vcap
+      wday: '*'
+    - script:
+      name: touch.sh
+      contents: |
+        #!/bin/bash
+
+        /usr/bin/touch /tmp/test-script-cron

--- a/templates/make_manifest
+++ b/templates/make_manifest
@@ -11,8 +11,8 @@ fail() {
 	echo >&2 $*
 }
 
-if [[ "$infrastructure" != "aws-ec2" && "$infrastructure" != "warden" ]] ; then
-  fail "usage: ./make_manifest <aws-ec2|warden>"
+if [[ "$infrastructure" != "aws-ec2" && "$infrastructure" != "warden" && "$infrastructure" != "openstack" ]] ; then
+  fail "usage: ./make_manifest <aws-ec2|warden|openstack>"
   exit 1
 fi
 
@@ -20,6 +20,7 @@ case "${infrastructure}/${STEMCELL_OS}" in
   (warden/*)       STEMCELL_URL="https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent" ;;
   (aws-ec2/ubuntu) STEMCELL_URL="https://bosh.io/d/stemcells/bosh-aws-xen-ubuntu-trusty-go_agent" ;;
   (aws-ec2/centos) STEMCELL_URL="https://bosh.io/d/stemcells/bosh-aws-xen-centos-7-go_agent" ;;
+  (openstack/ubuntu) STEMCELL_URL="https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-trusty-go_agent" ;;
   (*)
     fail "Invalid infrastructure or OS specified."
     exit 1
@@ -43,6 +44,14 @@ if [[ $infrastructure = "aws-ec2" && ${DIRECTOR_CPI} != "aws" ]]; then
   fail "Not targeting an AWS BOSH. Please make sure you have run 'bosh target' and are targeting an AWS BOSH before running this script."
   exit 1
 fi
+
+# to be reviewed !!
+if [[ $DIRECTOR_NAME = "openstack" && ${infrastructure} != "openstack" ]]; then
+  fail "Not targeting bosh-lite with openstack CPI. Please make sure you have run 'bosh target' and are targeting a BOSH lite before running this script."
+  exit 1
+fi
+
+# -----------------
 
 function latest_uploaded_stemcell {
   echo $(bosh stemcells | grep bosh | grep $STEMCELL_OS | awk -F'|' '{ print $2, $3 }' | sort -nr -k2 | head -n1 | awk '{ print $1 }')
@@ -73,8 +82,8 @@ if ! [ -x "$(command -v spruce)" ]; then
 fi
 
 spruce merge --prune meta \
-  $templates/deployment.yml \
-  $templates/jobs.yml \
+  $templates/deployment-${infrastructure}.yml \
+  $templates/jobs-${infrastructure}.yml \
   $templates/infrastructure-${infrastructure}.yml \
   $tmpdir/stub-with-uuid.yml \
   $* > $tmpdir/$NAME-manifest.yml

--- a/templates/manifest-openstack.yml
+++ b/templates/manifest-openstack.yml
@@ -25,8 +25,14 @@ properties:
       hour: '*'
       minute: '*'
       month: '*'
-      user: root
+      user: vcap
       wday: '*'
+    - script:
+      name: touch.sh
+      contents: |
+        #!/bin/bash
+
+        /usr/bin/touch /tmp/test-script-cron  
 releases:
 - name: cron
   version: latest

--- a/templates/manifest-openstack.yml
+++ b/templates/manifest-openstack.yml
@@ -1,0 +1,44 @@
+director_uuid: REPLACE_WITH_DIRECTOR_ID
+jobs:
+- instances: 1
+  name: cron
+  networks:
+  - default:
+    - dns
+    - gateway
+    name: REPLACE_WITH_YOUR_NETWORK
+    static_ips:
+    - 10.250.2.61
+  persistent_disk: 0
+  vm_type: default
+  stemcell: trusty
+  azs: [z1]
+  jobs:
+  - name: cron
+    release: cron
+name: cron-openstack
+properties:
+  cron:
+    entries:
+    - command: REPLACE_WITH_YOUR_COMMAND
+      day: '*'
+      hour: '*'
+      minute: '*'
+      month: '*'
+      user: root
+      wday: '*'
+releases:
+- name: cron
+  version: latest
+update:
+  canaries: 1
+  canary_watch_time: 1000-30000
+  max_in_flight: 50
+  serial: false
+  update_watch_time: 1000-30000
+
+stemcells:
+ - alias: trusty
+   os: ubuntu-trusty
+   version: latest
+


### PR DESCRIPTION
Orange internal review prior to offer PR to the CF community

---

This PR adds sample manifest for openstack CPI. Currently examples are provided for EC2 and warden CPI.

This uses the bosh [2.0 cloud-config](http://bosh.io/docs/cloud-config.html) syntax for configuring networks on the bosh-director.